### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/586/811/9/1125868119.geojson
+++ b/data/112/586/811/9/1125868119.geojson
@@ -43,6 +43,9 @@
     "name:hrv_x_preferred":[
         "Port Howard"
     ],
+    "name:ita_x_preferred":[
+        "Port Howard"
+    ],
     "name:jpn_x_preferred":[
         "\u30dd\u30fc\u30c8\u30fb\u30cf\u30ef\u30fc\u30c9"
     ],
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":1125868119,
-    "wof:lastmodified":1566596131,
+    "wof:lastmodified":1690893287,
     "wof:name":"Port Howard",
     "wof:parent_id":85681209,
     "wof:placetype":"locality",

--- a/data/112/601/553/7/1126015537.geojson
+++ b/data/112/601/553/7/1126015537.geojson
@@ -28,6 +28,9 @@
     "name:ara_x_preferred":[
         "\u0633\u062a\u0627\u0646\u0644\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u062a\u0627\u0646\u0644\u0649"
+    ],
     "name:ast_x_preferred":[
         "Stanley"
     ],
@@ -38,7 +41,8 @@
         "\u0413\u043e\u0440\u0430\u0434 \u0421\u0442\u044d\u043d\u043b\u0456"
     ],
     "name:bel_x_variant":[
-        "\u0413\u043e\u0440\u0430\u0434 \u041f\u043e\u0440\u0442-\u0421\u0442\u044d\u043d\u043b\u0456"
+        "\u0413\u043e\u0440\u0430\u0434 \u041f\u043e\u0440\u0442-\u0421\u0442\u044d\u043d\u043b\u0456",
+        "\u0421\u0442\u044d\u043d\u043b\u0456"
     ],
     "name:ben_x_preferred":[
         "\u09b8\u09cd\u099f\u09cd\u09af\u09be\u09a8\u09b2\u09bf"
@@ -60,6 +64,9 @@
     ],
     "name:ces_x_preferred":[
         "Port Stanley"
+    ],
+    "name:cym_x_preferred":[
+        "Stanley"
     ],
     "name:dan_x_preferred":[
         "Stanley"
@@ -103,10 +110,16 @@
     "name:fra_x_preferred":[
         "Port Stanley"
     ],
+    "name:frr_x_preferred":[
+        "Stanley"
+    ],
     "name:fry_x_preferred":[
         "Stanley"
     ],
     "name:gla_x_preferred":[
+        "Stanley"
+    ],
+    "name:gle_x_preferred":[
         "Stanley"
     ],
     "name:glg_x_preferred":[
@@ -142,6 +155,9 @@
     "name:ita_x_preferred":[
         "Port Stanley"
     ],
+    "name:ita_x_variant":[
+        "Stanley"
+    ],
     "name:jpn_x_preferred":[
         "\u30b9\u30bf\u30f3\u30ec\u30fc"
     ],
@@ -175,8 +191,14 @@
     "name:mar_x_preferred":[
         "\u092a\u094b\u0930\u094d\u091f \u0938\u094d\u091f\u0945\u0928\u094d\u0932\u0940"
     ],
+    "name:mkd_x_preferred":[
+        "\u0421\u0442\u0435\u043d\u043b\u0438"
+    ],
     "name:msa_x_preferred":[
         "Stanley"
+    ],
+    "name:mzn_x_preferred":[
+        "\u0627\u0633\u062a\u0646\u0644\u06cc"
     ],
     "name:nan_x_preferred":[
         "Stanley"
@@ -198,6 +220,9 @@
     ],
     "name:oss_x_preferred":[
         "\u041f\u043e\u0440\u0442-\u0421\u0442\u044d\u043d\u043b\u0438"
+    ],
+    "name:oss_x_variant":[
+        "\u0421\u0442\u044d\u043d\u043b\u0438"
     ],
     "name:pnb_x_preferred":[
         "\u0633\u0679\u06cc\u0646\u0644\u06d2"
@@ -265,6 +290,9 @@
     "name:urd_x_variant":[
         "\u0627\u0633\u0679\u06cc\u0646\u0644\u06d2"
     ],
+    "name:vec_x_preferred":[
+        "Porto Arzentin"
+    ],
     "name:vie_x_preferred":[
         "Stanley"
     ],
@@ -273,6 +301,9 @@
     ],
     "name:wol_x_preferred":[
         "Stanley"
+    ],
+    "name:wuu_x_preferred":[
+        "\u65af\u5766\u5229"
     ],
     "name:yid_x_preferred":[
         "\u05e1\u05d8\u05d0\u05e0\u05dc\u05d9"
@@ -323,7 +354,7 @@
         }
     ],
     "wof:id":1126015537,
-    "wof:lastmodified":1636494971,
+    "wof:lastmodified":1690893287,
     "wof:name":"Stanley",
     "wof:parent_id":85681209,
     "wof:placetype":"locality",

--- a/data/114/190/837/9/1141908379.geojson
+++ b/data/114/190/837/9/1141908379.geojson
@@ -72,6 +72,9 @@
     "name:nob_x_preferred":[
         "Fox Bay"
     ],
+    "name:pol_x_preferred":[
+        "Fox Bay"
+    ],
     "name:por_x_preferred":[
         "Ba\u00eda Fox"
     ],
@@ -225,7 +228,7 @@
         }
     ],
     "wof:id":1141908379,
-    "wof:lastmodified":1636494971,
+    "wof:lastmodified":1690893288,
     "wof:name":"Fox Bay",
     "wof:parent_id":85681209,
     "wof:placetype":"locality",

--- a/data/114/190/940/9/1141909409.geojson
+++ b/data/114/190/940/9/1141909409.geojson
@@ -24,6 +24,9 @@
     "name:ara_x_preferred":[
         "\u0633\u062a\u0627\u0646\u0644\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u062a\u0627\u0646\u0644\u0649"
+    ],
     "name:ast_x_preferred":[
         "Stanley"
     ],
@@ -32,6 +35,9 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041f\u043e\u0440\u0442-\u0421\u0442\u044d\u043d\u043b\u0456"
+    ],
+    "name:bel_x_variant":[
+        "\u0421\u0442\u044d\u043d\u043b\u0456"
     ],
     "name:ben_x_preferred":[
         "\u09b8\u09cd\u099f\u09cd\u09af\u09be\u09a8\u09b2\u09bf"
@@ -53,6 +59,9 @@
     ],
     "name:ces_x_preferred":[
         "Port Stanley"
+    ],
+    "name:cym_x_preferred":[
+        "Stanley"
     ],
     "name:dan_x_preferred":[
         "Stanley"
@@ -87,10 +96,16 @@
     "name:fra_x_preferred":[
         "Port Stanley"
     ],
+    "name:frr_x_preferred":[
+        "Stanley"
+    ],
     "name:fry_x_preferred":[
         "Stanley"
     ],
     "name:gla_x_preferred":[
+        "Stanley"
+    ],
+    "name:gle_x_preferred":[
         "Stanley"
     ],
     "name:glg_x_preferred":[
@@ -126,6 +141,9 @@
     "name:ita_x_preferred":[
         "Port Stanley"
     ],
+    "name:ita_x_variant":[
+        "Stanley"
+    ],
     "name:jpn_x_preferred":[
         "\u30b9\u30bf\u30f3\u30ea\u30fc"
     ],
@@ -153,8 +171,14 @@
     "name:mar_x_preferred":[
         "\u092a\u094b\u0930\u094d\u091f \u0938\u094d\u091f\u0945\u0928\u094d\u0932\u0940"
     ],
+    "name:mkd_x_preferred":[
+        "\u0421\u0442\u0435\u043d\u043b\u0438"
+    ],
     "name:msa_x_preferred":[
         "Stanley"
+    ],
+    "name:mzn_x_preferred":[
+        "\u0627\u0633\u062a\u0646\u0644\u06cc"
     ],
     "name:nan_x_preferred":[
         "Stanley"
@@ -173,6 +197,9 @@
     ],
     "name:oss_x_preferred":[
         "\u041f\u043e\u0440\u0442-\u0421\u0442\u044d\u043d\u043b\u0438"
+    ],
+    "name:oss_x_variant":[
+        "\u0421\u0442\u044d\u043d\u043b\u0438"
     ],
     "name:pnb_x_preferred":[
         "\u0633\u0679\u06cc\u0646\u0644\u06d2"
@@ -228,6 +255,9 @@
     "name:urd_x_preferred":[
         "\u0627\u0633\u0679\u06cc\u0646\u0644\u06d2"
     ],
+    "name:vec_x_preferred":[
+        "Porto Arzentin"
+    ],
     "name:vie_x_preferred":[
         "Stanley"
     ],
@@ -236,6 +266,9 @@
     ],
     "name:wol_x_preferred":[
         "Stanley"
+    ],
+    "name:wuu_x_preferred":[
+        "\u65af\u5766\u5229"
     ],
     "name:yid_x_preferred":[
         "\u05e1\u05d8\u05d0\u05e0\u05dc\u05d9"
@@ -366,7 +399,7 @@
         }
     ],
     "wof:id":1141909409,
-    "wof:lastmodified":1636494971,
+    "wof:lastmodified":1690893288,
     "wof:name":"Stanley",
     "wof:parent_id":85681209,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.